### PR TITLE
Cache packages & smaller fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ Show more info using `--help` with `tip` or concrete command.
 In order to use tip with VSCode you must install `tip` and then provide path to `tipython` executable as current
 interpreter. It will use **all installed libraries** in current tip directory. Read more in `tipython --help`.
 
+## Configuration
+
+Some settings can be configured using the `tip config set <key> <value>` command. Here is a list of keys you may want to
+change:
+
+| Setting             | Description                           |
+| ------------------- | ------------------------------------- |
+| `cache_dir`         | Directory where the packages cache is stored |
+| `site_packages_dir` | Directory where the packages are stored |
+
+There are additional keys in the config that are not listed here, as they are handled by special commands.
+
 ## Glossary
 
 **Package Specifier** - package name and version in format of `<package_name>==<package_version>`.
@@ -55,7 +67,7 @@ environment.
 
 ## Known Issues
 
-- Because of packages links we may reach packages that are not part of current environemnt but are part of other env
+- Because of packages links we may reach packages that are not part of current environment but are part of other env
 - `tip run -m module` error message when there is no `__main__.py` file may have better formatting
 - Uninstalling a package doesn't remove link: we must not just delete it but add link to other package version if it
 exists

--- a/README.md
+++ b/README.md
@@ -34,10 +34,12 @@ change:
 
 | Setting             | Description                           |
 | ------------------- | ------------------------------------- |
-| `cache_dir`         | Directory where the packages cache is stored |
-| `site_packages_dir` | Directory where the packages are stored |
+| `cache_dir`         | Directory where the packages cache is stored. When not set, cache is disabled. |
+| `site_packages_dir` | Directory where the packages are stored. |
 
 There are additional keys in the config that are not listed here, as they are handled by special commands.
+
+You can remove a setting by using `tip cache unset <key>`.
 
 ## Glossary
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,9 @@ packages = find:
 package_dir =
     = src
 
+[options.packages.find]
+where = src
+
 [options.entry_points]
 console_scripts =
     tip = tip.cli:app

--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ def prepare_scripts():
 
 
 def _add_tip_to_path():
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "src"))
     import tip
     rcfile_path = tip.shell.find_rcfile_path()
     if rcfile_path is None:

--- a/setup.py
+++ b/setup.py
@@ -51,8 +51,7 @@ def init_config():
         return
     config = {
         'site_packages_dir': os.path.join(TIP_DIR, 'site-packages'),
-        'active_environment_name': 'base',
-        'cache_dir': '/tmp/tip/cache'
+        'active_environment_name': 'base'
     }
     with open(config_path, mode='w+', encoding='utf8') as config_file:
         json.dump(config, config_file)

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,8 @@ def init_config():
         return
     config = {
         'site_packages_dir': os.path.join(TIP_DIR, 'site-packages'),
-        'active_environment_name': 'base'
+        'active_environment_name': 'base',
+        'cache_dir': '/tmp/tip/cache'
     }
     with open(config_path, mode='w+', encoding='utf8') as config_file:
         json.dump(config, config_file)

--- a/src/tip/cache.py
+++ b/src/tip/cache.py
@@ -1,0 +1,24 @@
+import os
+import shutil
+
+
+CACHE_DIR = "/tmp/tip/cache"
+
+
+def add(package_dir):
+    """Cache a package at `package_dir` and return path to its cache."""
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    version = os.path.basename(package_dir)
+    versions_dir = os.path.dirname(package_dir)
+    name = os.path.basename(versions_dir)
+    cache_dir = os.path.join(CACHE_DIR, name, version)
+    try:
+        shutil.copytree(package_dir, cache_dir)
+    except FileExistsError:
+        pass
+    return cache_dir
+
+
+def clear():
+    """Clear cache."""
+    shutil.rmtree(CACHE_DIR)

--- a/src/tip/cache.py
+++ b/src/tip/cache.py
@@ -12,10 +12,7 @@ def get(package_dir):
     """Get path to a cached `package_dir` or return it if can't be cached."""
     if CACHE_DIR is None:
         return package_dir
-    version = os.path.basename(package_dir)
-    versions_dir = os.path.dirname(package_dir)
-    name = os.path.basename(versions_dir)
-    cache_dir = os.path.join(CACHE_DIR, name, version)
+    cache_dir = __path(package_dir)
     try:
         cached_mtime = os.path.getmtime(cache_dir)
     except FileNotFoundError:
@@ -23,21 +20,32 @@ def get(package_dir):
     if cached_mtime > os.path.getmtime(package_dir):
         return package_dir
     os.makedirs(cache_dir, exist_ok=True)
-    temp_dir = os.path.join(CACHE_DIR, name, secrets.token_hex(16) + '~')
+    temp_dir = os.path.join(CACHE_DIR, secrets.token_hex(16) + '~')
     shutil.copytree(package_dir, temp_dir)
     try:
         os.rename(temp_dir, cache_dir)
     except FileExistsError:
-        pass
-    finally:
         shutil.rmtree(temp_dir)
     return cache_dir
 
 
-def clear():
+def clear(package_dir):
     """Clear cache."""
-    if CACHE_DIR is not None and os.path.exists(CACHE_DIR):
-        shutil.rmtree(CACHE_DIR)
+    if CACHE_DIR is None:
+        return
+    cache_dir = __path(package_dir)
+    try:
+        shutil.rmtree(cache_dir)
+    except FileNotFoundError:
+        pass
+
+
+def __path(package_dir):
+    """Construct path to a package cache."""
+    version = os.path.basename(package_dir)
+    versions_dir = os.path.dirname(package_dir)
+    name = os.path.basename(versions_dir)
+    return os.path.join(CACHE_DIR, name, version)
 
 
 def is_enabled():

--- a/src/tip/cache.py
+++ b/src/tip/cache.py
@@ -9,7 +9,10 @@ CACHE_DIR = config.get('cache_dir')
 
 def add(package_dir):
     """Cache a package at `package_dir` and return path to its cache."""
-    os.makedirs(CACHE_DIR, exist_ok=True)
+    try:
+        os.makedirs(CACHE_DIR, exist_ok=True)
+    except TypeError:
+        raise RuntimeError("Cache is disabled") from None
     version = os.path.basename(package_dir)
     versions_dir = os.path.dirname(package_dir)
     name = os.path.basename(versions_dir)
@@ -23,4 +26,12 @@ def add(package_dir):
 
 def clear():
     """Clear cache."""
-    shutil.rmtree(CACHE_DIR)
+    try:
+        shutil.rmtree(CACHE_DIR)
+    except TypeError:
+        raise RuntimeError("Cache is disabled") from None
+
+
+def is_enabled():
+    """Check if cache is enabled."""
+    return CACHE_DIR is not None

--- a/src/tip/cache.py
+++ b/src/tip/cache.py
@@ -1,8 +1,10 @@
 import os
 import shutil
 
+from tip import config
 
-CACHE_DIR = "/tmp/tip/cache"
+
+CACHE_DIR = config.get('cache_dir')
 
 
 def add(package_dir):

--- a/src/tip/cli.py
+++ b/src/tip/cli.py
@@ -199,7 +199,15 @@ def remove(package_specifiers: tuple[str], environment_path: str | None):
 @click.argument('key', type=str)
 @click.argument('value', type=str)
 def set_(key: str, value: str):
+    """Set the config `key` to be `value`."""
     config[key] = value
+
+
+@config_.command('unset')
+@click.argument('key', type=str)
+def unset(key: str):
+    """Remove value of config named `key`."""
+    config[key] = None
 
 
 def _at_most_one(*args: bool) -> bool:

--- a/src/tip/cli.py
+++ b/src/tip/cli.py
@@ -16,6 +16,11 @@ def app():
     """TIP package manager."""
 
 
+@app.group(name="config")
+def config_():
+    """Configuration management."""
+
+
 @app.command()
 @click.argument('environment_name', type=str)
 def activate(environment_name: str):
@@ -28,13 +33,15 @@ def activate(environment_name: str):
 
 @app.command()
 def info():
-    """Display information about current tip environment."""
+    """Display information about current tip state."""
     site_packages_dir = config.get('site_packages_dir')
     active_env_name = config.get('active_environment_name')
+    cache_dir = config.get('cache_dir')
     active_env_path = Environment.locate(active_env_name)
-    click.echo(f"active env: {active_env_name}")
-    click.echo(f"active env location: {active_env_path}")
-    click.echo(f"site-packages directory: {site_packages_dir}")
+    click.echo(f"active env: {active_env_name!r}")
+    click.echo(f"active env location: {active_env_path!r}")
+    click.echo(f"site-packages directory: {site_packages_dir!r}")
+    click.echo(f"cache directory: {cache_dir!r}")
 
 
 @app.command()
@@ -186,6 +193,13 @@ def remove(package_specifiers: tuple[str], environment_path: str | None):
             click.echo(f"Package {package_specifier!r} not in environment")
         except ValueError:
             click.echo(f"Package {package_specifier!r} is in environment with different version")
+
+
+@config_.command('set')
+@click.argument('key', type=str)
+@click.argument('value', type=str)
+def set_(key: str, value: str):
+    config[key] = value
 
 
 def _at_most_one(*args: bool) -> bool:

--- a/src/tip/cli.py
+++ b/src/tip/cli.py
@@ -6,7 +6,7 @@ import rich
 import click
 import rich.tree
 
-from tip import config, packages, runner
+from tip import cache, config, packages, runner
 from tip.config import LINKS_DIR
 from tip.environment import Environment
 
@@ -42,6 +42,7 @@ def info():
 @click.argument('package_specifiers', type=str, nargs=-1)
 def install(package_specifiers: list[str], environment_path: str | None):
     """Download and install packages by PACKAGE_SPECIFIERS to make them runnable with `tip run`."""
+    cache.clear()
     if environment_path is not None:
         env = Environment.load(path=environment_path)
     else:
@@ -59,6 +60,7 @@ def install(package_specifiers: list[str], environment_path: str | None):
 @click.argument('package_specifiers', type=str, nargs=-1)
 def uninstall(package_specifiers: tuple[str]):
     """Uninstall packages identified by package specifiers from site-packages."""
+    cache.clear()
     existing_package_specifiers = []
     for package_specifier in package_specifiers:
         if not packages.is_valid(package_specifier):

--- a/src/tip/cli.py
+++ b/src/tip/cli.py
@@ -1,5 +1,7 @@
 import os
 import sys
+import json
+from collections import deque
 from typing import no_type_check
 
 import rich
@@ -45,20 +47,24 @@ def info():
 
 
 @app.command()
-@click.option('--env', '-e', 'environment_path', type=str, default=None)
 @click.argument('package_specifiers', type=str, nargs=-1)
-def install(package_specifiers: list[str], environment_path: str | None):
-    """Download and install packages by PACKAGE_SPECIFIERS to make them runnable with `tip run`."""
-    cache.clear()
-    if environment_path is not None:
+@click.option('--env', '-e', 'environment_path', type=str, default=None)
+def install(package_specifiers: list[str], environment_path: str):
+    """
+    Download and install packages to make them runnable with `tip run`.
+
+    When PACKAGE_SPECIFIERS is not empty, install all these packages. If given ENVIRONMENT_PATH, install all packages
+    from this environment. Otherwise install packages from the active environment.
+    """
+    if not _at_most_one(package_specifiers, environment_path):
+        raise click.ClickException("At most one of PACKAGE_SPECIFIERS or ENVIRONMENT_PATH should be specified")
+    if len(package_specifiers) == 0:
+        environment_path = environment_path or Environment.locate(config.get('active_environment_name'))
         env = Environment.load(path=environment_path)
-    else:
-        env = Environment.load(name=config.get('active_environment_name'))
+        package_specifiers = [packages.make_package_specifier(k, v) for k, v in env.packages.items()]
+    cache.clear()
     try:
         packages.install(package_specifiers)
-        for package_specifier in package_specifiers:
-            env.add_package(package_specifier)
-        env.save()
     except Exception as ex:
         raise click.ClickException(str(ex))
 
@@ -81,28 +87,66 @@ def uninstall(package_specifiers: tuple[str]):
 
 
 @app.command(name='list')
-@click.option('--active-env', '-a', 'active_env', is_flag=True)
-@click.option('--path', '-p', 'env_path', type=str, default="")
-@click.option('--name', '-n', 'env_name', type=str, default="")
+@click.option('--env', '-e', 'environment_path', type=str, default=None)
+@click.option('--installed', '-i', 'installed', is_flag=True, default=False)
 @no_type_check
-def list_(active_env: bool, env_path: str, env_name: str):
-    """Displays tree: ACTIVE_ENV, ENV_PATH or ENV_NAME environment packages or installed packages without options."""
-    if not _at_most_one(active_env, env_path != "", env_name != ""):
-        raise click.ClickException("At most one of ACTIVE_ENV, ENV_PATH or ENV_NAME should be specified")
-    if active_env:
-        tree = _make_environment_packages_tree(Environment.locate(config.get('active_environment_name')))
-    elif env_path != "":
-        tree = _make_environment_packages_tree(env_path)
-    elif env_name != "":
-        tree = _make_environment_packages_tree(Environment.locate(env_name))
+def list_(environment_path: str | None, installed: bool):
+    """
+    Show list of packages.
+
+    If ENVIRONMENT_PATH is set, then display packages in this environment. If used with INSTALLED, displays all
+    installed packages. Without these options it displays packages in the active environment
+    """
+    if not _at_most_one(environment_path, installed):
+        raise click.ClickException("At most one of ENVIRONMENT_PATH or INSTALLED should be specified")
+    if not installed:
+        environment_path = environment_path or Environment.locate(config.get('active_environment_name'))
+        tree = _make_environment_packages_tree(environment_path)
     else:
         tree = _make_installed_packages_tree()
     rich.print(tree)
 
 
+@app.command()
+@click.option('--env', '-e', 'environment_path', type=str, default=None)
+def dependencies(environment_path: str | None):
+    """
+    Display dependencies of the dependencies.
+
+    It shows dependencies of the packages that are in the environment  at ENVIRONMENT_PATH or in the active environment.
+    It doesn't show packages that are present in the environment. This is helpful when you need to add these packages
+    to the environment using `tip add` command.
+    """
+    if environment_path is None:
+        env = Environment.load(name=config.get('active_environment_name'))
+    else:
+        env = Environment.load(path=environment_path)
+    env_packages = [packages.make_package_specifier(k, v) for k, v in env.packages.items()]
+    queue = deque(env_packages)
+    seen = set(env_packages)
+    dependencies_list = []
+    while len(queue) > 0:
+        package = queue.popleft()
+        package_dir = packages.locate(*packages.parse_package_specifier(package))
+        try:
+            with open(os.path.join(package_dir, "dependencies.json")) as f:
+                dependencies = json.load(f)
+        except FileNotFoundError:
+            click.echo(f"{package} is not installed or corrupted, skipping its dependencies")
+            continue
+        for dependency in dependencies:
+            if dependency in seen:
+                continue
+            dependencies_list.append(dependency)
+            queue.append(dependency)
+            seen.add(dependency)
+    if len(dependencies_list) > 0:
+        click.echo(' '.join(dependencies_list))
+
+
 @app.command(context_settings={'ignore_unknown_options': True})
 @click.option('-m', '--module', 'module_name', type=str)
-@click.option('--env', '-e', 'environment_path', type=str)
+@click.option('--env', '-e', 'environment_path', type=str, default=None)
 @click.option('-c', 'command')
 @click.option('--install-missing', 'install_missing', is_flag=True)
 @click.argument('args', nargs=-1, type=click.UNPROCESSED)
@@ -147,10 +191,7 @@ def create(environment_name: str):
 @app.command()
 @click.option('--from_path', '-f', 'from_path', type=str, help="Environment to add all packages from")
 @click.argument('package_specifiers', type=str, nargs=-1)
-@click.option(
-    '--environment_path', '-e', 'environment_path', type=str,
-    help="Path of the environment to add packages to", required=False, default=None
-)
+@click.option('--env', '-e', 'environment_path', type=str, default=None)
 def add(package_specifiers: tuple[str], environment_path: str | None, from_path: str):
     """
     Add packages to the environment.
@@ -175,7 +216,7 @@ def add(package_specifiers: tuple[str], environment_path: str | None, from_path:
 
 @app.command()
 @click.argument('package_specifiers', type=str, nargs=-1)
-@click.option('--environment_path', '-e', 'environment_path', type=str, default=None)
+@click.option('--env', '-e', 'environment_path', type=str, default=None)
 def remove(package_specifiers: tuple[str], environment_path: str | None):
     """
     Remove packages from the environment.
@@ -193,6 +234,7 @@ def remove(package_specifiers: tuple[str], environment_path: str | None):
             click.echo(f"Package {package_specifier!r} not in environment")
         except ValueError:
             click.echo(f"Package {package_specifier!r} is in environment with different version")
+    env.save()
 
 
 @config_.command('set')
@@ -212,7 +254,7 @@ def unset(key: str):
 
 def _at_most_one(*args: bool) -> bool:
     """Returns True if at most one of the arguments is True."""
-    return sum(args) <= 1
+    return sum(bool(x) for x in args) <= 1
 
 
 def _make_installed_packages_tree() -> rich.tree.Tree:

--- a/src/tip/cli.py
+++ b/src/tip/cli.py
@@ -62,7 +62,6 @@ def install(package_specifiers: list[str], environment_path: str):
         environment_path = environment_path or Environment.locate(config.get('active_environment_name'))
         env = Environment.load(path=environment_path)
         package_specifiers = [packages.make_package_specifier(k, v) for k, v in env.packages.items()]
-    cache.clear()
     try:
         packages.install(package_specifiers)
     except Exception as ex:
@@ -73,7 +72,6 @@ def install(package_specifiers: list[str], environment_path: str):
 @click.argument('package_specifiers', type=str, nargs=-1)
 def uninstall(package_specifiers: tuple[str]):
     """Uninstall packages identified by package specifiers from site-packages."""
-    cache.clear()
     existing_package_specifiers = []
     for package_specifier in package_specifiers:
         if not packages.is_valid(package_specifier):
@@ -84,6 +82,8 @@ def uninstall(package_specifiers: tuple[str]):
             existing_package_specifiers.append(package_specifier)
     for package_specifier in existing_package_specifiers:
         packages.uninstall(package_specifier)
+        package_dir = packages.locate(*packages.parse_package_specifier(package_specifier))
+        cache.clear(package_dir)
 
 
 @app.command(name='list')

--- a/src/tip/packages.py
+++ b/src/tip/packages.py
@@ -1,6 +1,9 @@
 import os
+import json
 import shutil
+import tempfile
 import subprocess
+from collections import deque
 
 from tip import config
 from tip.util import parse_package_specifier
@@ -22,12 +25,28 @@ def make_package_specifier(package_name: str, package_version: str) -> str:
 
 def install(package_specifiers: list[str]):
     """Install packages identified by `package_specifiers`."""
-    for package_specifier in package_specifiers:
-        if is_valid(package_specifier):
-            continue
-        raise RuntimeError(f"Invalid package specifier: {package_specifier!r}")
-    for package_specifier in package_specifiers:
-        _install(package_specifier)
+    queue = deque(package_specifiers)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        while len(queue) > 0:
+            package_specifier = queue.popleft()
+            if not is_valid(package_specifier):
+                raise RuntimeError(f"Invalid package specifier: {package_specifier!r}")
+            if is_installed(package_specifier):
+                continue
+            download_output = subprocess.check_output(
+                f"pip download --no-deps {package_specifier}",
+                shell=True,
+                cwd=temp_dir
+            )
+            wheel_path = os.path.join(temp_dir, download_output.decode('utf8').split('\n')[-3].replace('Saved ', ''))
+            dry_run_report_path = os.path.join(temp_dir, 'dry-run-report.json')
+            subprocess.run(f"pip install --dry-run {wheel_path} --report {dry_run_report_path}", shell=True, check=True)
+            with open(dry_run_report_path) as report_file:
+                dry_run_report = json.load(report_file)
+                for package in dry_run_report['install']:
+                    package_metadata = package['metadata']
+                    queue.append(f"{package_metadata['name']}=={package_metadata['version']}")
+            _install(package_specifier, wheel_path=wheel_path)
 
 
 def make_link(package_specifier: str):
@@ -62,16 +81,20 @@ def uninstall(package_specifier: str):
     shutil.rmtree(package_dir)
 
 
-def _install(package_specifier: str):
-    """Install new package identified by `package_specifier` to make it available for environments."""
+def _install(package_specifier: str, /, *, wheel_path: str = None):
+    """
+    Install new package identified by `package_specifier` to make it available for environments.
+
+    If `wheel_path` it will be used to install the package without redownloading its wheel.
+    """
     package_name, package_version = parse_package_specifier(package_specifier)
     package_dir = locate(package_name, package_version)
     if os.path.exists(package_dir):
         return
     os.makedirs(package_dir)
-    command = f"pip install --target={package_dir} --no-deps {package_specifier}"
+    command = f"pip install --target={package_dir} --no-deps {wheel_path or package_specifier}"
     try:
-        subprocess.check_output(command, shell=True)
+        subprocess.run(command, shell=True, check=True)
     except Exception as ex:
         shutil.rmtree(package_dir)
         raise RuntimeError(f"Error while installing package {package_specifier!r}") from ex

--- a/src/tip/packages.py
+++ b/src/tip/packages.py
@@ -32,6 +32,7 @@ def install(package_specifiers: list[str]):
 
 def make_link(package_specifier: str):
     """Make link to package identified by `package_specifier` in links directory."""
+    os.makedirs(config.LINKS_DIR, exist_ok=True)
     package_dir = locate(*parse_package_specifier(package_specifier))
     for folder_name in os.listdir(package_dir):
         folder_path = os.path.join(package_dir, folder_name)
@@ -68,7 +69,7 @@ def _install(package_specifier: str):
     if os.path.exists(package_dir):
         return
     os.makedirs(package_dir)
-    command = f"pip install --target={package_dir} {package_specifier}"
+    command = f"pip install --target={package_dir} --no-deps {package_specifier}"
     try:
         subprocess.check_output(command, shell=True)
     except Exception as ex:

--- a/src/tip/packages.py
+++ b/src/tip/packages.py
@@ -5,7 +5,7 @@ import tempfile
 import subprocess
 from collections import deque
 
-from tip import config
+from tip import cache, config
 from tip.util import parse_package_specifier
 
 
@@ -102,4 +102,5 @@ def _install(package_specifier: str, /, *, wheel_path: str = None, dependencies=
         raise RuntimeError(f"Error while installing package {package_specifier!r}") from ex
     with open(os.path.join(package_dir, "dependencies.json"), mode='w') as dependencies_file:
         json.dump(dependencies or {}, dependencies_file)
+    cache.get(package_dir)  # Invalidate cache
     make_link(package_specifier)

--- a/src/tip/tip_meta_finder.py
+++ b/src/tip/tip_meta_finder.py
@@ -1,7 +1,8 @@
 import os
-import shutil
 from importlib.abc import MetaPathFinder
 from importlib.util import spec_from_file_location
+
+from tip import cache
 
 
 class TipMetaFinder(MetaPathFinder):
@@ -18,7 +19,7 @@ class TipMetaFinder(MetaPathFinder):
             try:
                 path.append(self.packages_to_mount_cache[fullname])
             except KeyError:
-                self.packages_to_mount_cache[fullname] = _cache_package(self.packages_to_mount[fullname])
+                self.packages_to_mount_cache[fullname] = cache.add(self.packages_to_mount[fullname])
                 path.append(self.packages_to_mount_cache[fullname])
         if len(path) == 0:
             path.append(os.getcwd())
@@ -36,15 +37,3 @@ class TipMetaFinder(MetaPathFinder):
                 continue
             return spec_from_file_location(fullname, filename, submodule_search_locations=submodule_locations)
         return None
-
-
-def _cache_package(package_dir):
-    version = os.path.basename(package_dir)
-    versions_dir = os.path.dirname(package_dir)
-    name = os.path.basename(versions_dir)
-    cache_dir = os.path.join('/tmp/tip/cache', name, version)
-    try:
-        shutil.copytree(package_dir, cache_dir)
-    except FileExistsError:
-        pass
-    return cache_dir

--- a/src/tip/tip_meta_finder.py
+++ b/src/tip/tip_meta_finder.py
@@ -17,13 +17,7 @@ class TipMetaFinder(MetaPathFinder):
         # pylint: disable=unused-argument
         path = []
         if fullname in self.packages_to_mount:
-            try:
-                path.append(self.packages_to_mount_cache[fullname])
-            except KeyError:
-                self.packages_to_mount_cache[fullname] = cache.add(self.packages_to_mount[fullname])
-                path.append(self.packages_to_mount_cache[fullname])
-            except AttributeError:
-                path.append(self.packages_to_mount[fullname])
+            path.append(cache.get(self.packages_to_mount[fullname]))
         if len(path) == 0:
             path.append(os.getcwd())
         if "." in fullname:

--- a/src/tip/tip_meta_finder.py
+++ b/src/tip/tip_meta_finder.py
@@ -10,7 +10,8 @@ class TipMetaFinder(MetaPathFinder):
 
     def __init__(self, packages_to_mount):
         self.packages_to_mount = packages_to_mount
-        self.packages_to_mount_cache = {}
+        if cache.is_enabled():
+            self.packages_to_mount_cache = {}
 
     def find_spec(self, fullname, path, target=None):
         # pylint: disable=unused-argument
@@ -21,6 +22,8 @@ class TipMetaFinder(MetaPathFinder):
             except KeyError:
                 self.packages_to_mount_cache[fullname] = cache.add(self.packages_to_mount[fullname])
                 path.append(self.packages_to_mount_cache[fullname])
+            except AttributeError:
+                path.append(self.packages_to_mount[fullname])
         if len(path) == 0:
             path.append(os.getcwd())
         if "." in fullname:


### PR DESCRIPTION
Besides adding packages cache there are several important fixes:
1. `setup.py` didn't work since we moved to `src` layout. It turned out that while `setup.py` is running there is no way for current package to be available for import. `import tip` did work because it was always installed from current dir: `pip install .`. Since there is no directory `tip` now (only `src/tip`) it was raising an error.
2. When we install a package that has dependencies we may end up with several installation of the same package (`TIP` was born to fight against it). For example if we install `numpy` and `matplotlib` we are going to second `numpy`s in `matplotlib` directory. I've disabled `pip`'s dependency resolver. It is mandatory to implement our own dependency resolver now which doesn't seem difficult to do.