### PR TITLE
Fix submodule import handling in finder

### DIFF
--- a/src/tip/tip_meta_finder.py
+++ b/src/tip/tip_meta_finder.py
@@ -22,7 +22,8 @@ class TipMetaFinder(MetaPathFinder):
             path.append(os.getcwd())
         if "." in fullname:
             *_, name = fullname.split(".")
-        name = fullname
+        else:
+            name = fullname
         for entry in path:
             if os.path.isdir(os.path.join(entry, name)):
                 filename = os.path.join(entry, name, "__init__.py")


### PR DESCRIPTION
## Summary
- fix name extraction in TipMetaFinder when handling dotted module names

## Testing
- `pre-commit` *(fails: command not found)*